### PR TITLE
Add rulesStore and fiveToolsAdapter (Issues #20, #21)

### DIFF
--- a/src/stores/rulesStore.ts
+++ b/src/stores/rulesStore.ts
@@ -1,0 +1,109 @@
+import { defineStore } from 'pinia'
+import {
+  ABILITIES,
+  SKILLS,
+  PROFICIENCY_BONUS_PROGRESSION,
+  SPELL_SLOT_PROGRESSION,
+  CLASSES,
+  SPECIES,
+  BACKGROUNDS,
+} from '@/data/rules.js'
+
+interface RulesState {
+  abilities: Record<string, string>
+  skills: Record<string, string>
+  proficiencyBonusProgression: Record<number, number>
+  spellSlotProgression: Record<string, Record<number, Record<string, number>>>
+  classes: Record<string, unknown>
+  species: Record<string, unknown>
+  backgrounds: Record<string, unknown>
+  spells: unknown[]
+  feats: unknown[]
+}
+
+export const useRulesStore = defineStore('rules', {
+  state: (): RulesState => ({
+    abilities: { ...ABILITIES },
+    skills: { ...SKILLS },
+    proficiencyBonusProgression: { ...PROFICIENCY_BONUS_PROGRESSION },
+    spellSlotProgression: JSON.parse(JSON.stringify(SPELL_SLOT_PROGRESSION)),
+    classes: JSON.parse(JSON.stringify(CLASSES)),
+    species: JSON.parse(JSON.stringify(SPECIES)),
+    backgrounds: JSON.parse(JSON.stringify(BACKGROUNDS)),
+    spells: [],
+    feats: [],
+  }),
+
+  getters: {
+    // Expose current rules data for consumption by components
+    allClasses: (state) => state.classes,
+    allSpecies: (state) => state.species,
+    allBackgrounds: (state) => state.backgrounds,
+    allSpells: (state) => state.spells,
+    allFeats: (state) => state.feats,
+  },
+
+  actions: {
+    /**
+     * Import data into a specific category, replacing existing data.
+     * @param category - The data category to replace (e.g., 'spells', 'feats', 'classes')
+     * @param dataArray - The array of data to import
+     */
+    importData(category: string, dataArray: unknown[]) {
+      const validCategories = [
+        'spells',
+        'feats',
+        'classes',
+        'species',
+        'backgrounds',
+      ]
+
+      if (!validCategories.includes(category)) {
+        console.warn(`Invalid category: ${category}. Valid categories:`, validCategories)
+        return
+      }
+
+      // For arrays (spells, feats), replace directly
+      if (category === 'spells' || category === 'feats') {
+        ;(this as any)[category] = [...dataArray]
+        console.log(`Imported ${dataArray.length} items into ${category}`)
+        return
+      }
+
+      // For objects (classes, species, backgrounds), convert array to keyed object
+      // Assuming each item has a 'name' property
+      const dataObject: Record<string, unknown> = {}
+      for (const item of dataArray) {
+        if (item && typeof item === 'object' && 'name' in item) {
+          const name = (item as { name: string }).name
+          dataObject[name] = item
+        }
+      }
+
+      ;(this as any)[category] = dataObject
+      console.log(`Imported ${Object.keys(dataObject).length} items into ${category}`)
+    },
+
+    /**
+     * Reset a category to its original state (from rules.js)
+     */
+    resetCategory(category: string) {
+      const defaults: Record<string, unknown> = {
+        abilities: { ...ABILITIES },
+        skills: { ...SKILLS },
+        proficiencyBonusProgression: { ...PROFICIENCY_BONUS_PROGRESSION },
+        spellSlotProgression: JSON.parse(JSON.stringify(SPELL_SLOT_PROGRESSION)),
+        classes: JSON.parse(JSON.stringify(CLASSES)),
+        species: JSON.parse(JSON.stringify(SPECIES)),
+        backgrounds: JSON.parse(JSON.stringify(BACKGROUNDS)),
+        spells: [],
+        feats: [],
+      }
+
+      if (category in defaults) {
+        ;(this as any)[category] = defaults[category]
+        console.log(`Reset ${category} to default`)
+      }
+    },
+  },
+})

--- a/src/utils/fiveToolsAdapter.ts
+++ b/src/utils/fiveToolsAdapter.ts
@@ -1,0 +1,157 @@
+/**
+ * Adapter utilities for importing 5e.tools JSON data.
+ * Converts 5e.tools specific formats (tags, nested entries) into clean Markdown strings.
+ */
+
+/**
+ * Recursively processes 5e.tools entries arrays and converts them to Markdown strings.
+ * Handles nested arrays, objects, and inline tags like {@spell ...}, {@damage ...}, etc.
+ *
+ * @param entries - The entries array/object from 5e.tools data
+ * @returns Clean Markdown string
+ */
+export function sanitizeText(entries: unknown): string {
+  // Handle null/undefined
+  if (entries === null || entries === undefined) {
+    return ''
+  }
+
+  // Handle string input
+  if (typeof entries === 'string') {
+    return processInlineTags(entries)
+  }
+
+  // Handle array of entries
+  if (Array.isArray(entries)) {
+    const processed = entries
+      .map((entry) => sanitizeText(entry))
+      .filter((text) => text.trim().length > 0)
+    return processed.join('\n\n')
+  }
+
+  // Handle object entries (like {type: "entries", name: "...", entries: [...]})
+  if (typeof entries === 'object') {
+    const obj = entries as Record<string, unknown>
+
+    // Handle table structures
+    if (obj.type === 'table') {
+      return processTable(obj)
+    }
+
+    // Handle list structures
+    if (obj.type === 'list') {
+      return processList(obj)
+    }
+
+    // Handle nested entries
+    if (obj.type === 'entries' && Array.isArray(obj.entries)) {
+      let result = ''
+      if (obj.name && typeof obj.name === 'string') {
+        result = `**${processInlineTags(obj.name)}**\n\n`
+      }
+      result += sanitizeText(obj.entries)
+      return result
+    }
+
+    // Handle inline entries (bold/italic/etc.)
+    if (obj.type === 'inline' && typeof obj.entries === 'string') {
+      return processInlineTags(obj.entries)
+    }
+
+    // If it has a 'entries' property, recurse into it
+    if (obj.entries) {
+      return sanitizeText(obj.entries)
+    }
+
+    // Otherwise, try to stringify it
+    return String(obj)
+  }
+
+  return String(entries)
+}
+
+/**
+ * Process inline 5e.tools tags and convert them to Markdown
+ */
+function processInlineTags(text: string): string {
+  let result = text
+
+  // {@spell SpellName} -> *SpellName*
+  result = result.replace(/\{@spell ([^}]+)\}/gi, '*$1*')
+
+  // {@item ItemName} -> *ItemName*
+  result = result.replace(/\{@item ([^}]+)\}/gi, '*$1*')
+
+  // {@creature CreatureName} -> **CreatureName**
+  result = result.replace(/\{@creature ([^}]+)\}/gi, '**$1**')
+
+  // {@condition ConditionName} -> *ConditionName*
+  result = result.replace(/\{@condition ([^}]+)\}/gi, '*$1*')
+
+  // {@damage 1d6} -> 1d6
+  result = result.replace(/\{@damage ([^}]+)\}/gi, '$1')
+
+  // {@dice 1d20} -> 1d20
+  result = result.replace(/\{@dice ([^}]+)\}/gi, '$1')
+
+  // {@dc 15} -> DC 15
+  result = result.replace(/\{@dc (\d+)\}/gi, 'DC $1')
+
+  // {@hit +5} -> +5
+  result = result.replace(/\{@hit ([^}]+)\}/gi, '$1')
+
+  // {@atk mw} -> melee weapon attack
+  result = result.replace(/\{@atk mw\}/gi, 'melee weapon attack')
+  result = result.replace(/\{@atk rw\}/gi, 'ranged weapon attack')
+  result = result.replace(/\{@atk ms\}/gi, 'melee spell attack')
+  result = result.replace(/\{@atk rs\}/gi, 'ranged spell attack')
+
+  // {@skill SkillName} -> SkillName
+  result = result.replace(/\{@skill ([^}]+)\}/gi, '$1')
+
+  // {@ability str} -> Strength
+  const abilityMap: Record<string, string> = {
+    str: 'Strength',
+    dex: 'Dexterity',
+    con: 'Constitution',
+    int: 'Intelligence',
+    wis: 'Wisdom',
+    cha: 'Charisma',
+  }
+  result = result.replace(/\{@ability ([^}]+)\}/gi, (match, ability) => {
+    return abilityMap[ability.toLowerCase()] || ability
+  })
+
+  // Clean up any remaining unprocessed tags (generic fallback)
+  result = result.replace(/\{@\w+ ([^}]+)\}/gi, '$1')
+
+  return result
+}
+
+/**
+ * Process table structures (simplified - can be expanded)
+ */
+function processTable(obj: Record<string, unknown>): string {
+  // For now, just extract the caption if available
+  if (obj.caption && typeof obj.caption === 'string') {
+    return `**Table: ${processInlineTags(obj.caption)}**`
+  }
+  return '[Table]'
+}
+
+/**
+ * Process list structures
+ */
+function processList(obj: Record<string, unknown>): string {
+  if (!Array.isArray(obj.items)) {
+    return ''
+  }
+
+  return obj.items
+    .map((item) => {
+      const text = sanitizeText(item)
+      return text ? `- ${text}` : ''
+    })
+    .filter((line) => line.length > 0)
+    .join('\n')
+}

--- a/test/fiveToolsAdapter.test.ts
+++ b/test/fiveToolsAdapter.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeText } from '../src/utils/fiveToolsAdapter'
+
+describe('fiveToolsAdapter', () => {
+  describe('sanitizeText', () => {
+    it('returns empty string for null/undefined', () => {
+      expect(sanitizeText(null)).toBe('')
+      expect(sanitizeText(undefined)).toBe('')
+    })
+
+    it('processes plain strings without tags', () => {
+      expect(sanitizeText('Hello world')).toBe('Hello world')
+    })
+
+    it('converts {@spell} tags to italic markdown', () => {
+      const input = 'You cast {@spell fireball} and {@spell magic missile}.'
+      const expected = 'You cast *fireball* and *magic missile*.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@damage} tags to plain text', () => {
+      const input = 'Deals {@damage 2d6} fire damage.'
+      const expected = 'Deals 2d6 fire damage.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@dc} tags correctly', () => {
+      const input = 'Make a {@dc 15} Dexterity saving throw.'
+      const expected = 'Make a DC 15 Dexterity saving throw.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@hit} tags to plain text', () => {
+      const input = 'Attack bonus: {@hit +5}'
+      const expected = 'Attack bonus: +5'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@creature} tags to bold markdown', () => {
+      const input = 'You encounter a {@creature goblin}.'
+      const expected = 'You encounter a **goblin**.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@item} tags to italic markdown', () => {
+      const input = 'You find a {@item longsword}.'
+      const expected = 'You find a *longsword*.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@condition} tags to italic markdown', () => {
+      const input = 'The target is {@condition poisoned}.'
+      const expected = 'The target is *poisoned*.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@skill} tags to plain text', () => {
+      const input = 'Make a {@skill Stealth} check.'
+      const expected = 'Make a Stealth check.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('converts {@ability} tags to full ability names', () => {
+      const input = 'Add your {@ability str} modifier.'
+      const expected = 'Add your Strength modifier.'
+      expect(sanitizeText(input)).toBe(expected)
+
+      expect(sanitizeText('{@ability dex}')).toBe('Dexterity')
+      expect(sanitizeText('{@ability con}')).toBe('Constitution')
+      expect(sanitizeText('{@ability int}')).toBe('Intelligence')
+      expect(sanitizeText('{@ability wis}')).toBe('Wisdom')
+      expect(sanitizeText('{@ability cha}')).toBe('Charisma')
+    })
+
+    it('converts {@atk} tags to descriptive text', () => {
+      expect(sanitizeText('{@atk mw}')).toBe('melee weapon attack')
+      expect(sanitizeText('{@atk rw}')).toBe('ranged weapon attack')
+      expect(sanitizeText('{@atk ms}')).toBe('melee spell attack')
+      expect(sanitizeText('{@atk rs}')).toBe('ranged spell attack')
+    })
+
+    it('handles multiple different tags in one string', () => {
+      const input =
+        'Cast {@spell fireball} for {@damage 8d6} damage, {@dc 15} Dex save for half.'
+      const expected = 'Cast *fireball* for 8d6 damage, DC 15 Dex save for half.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('processes string arrays and joins with double newlines', () => {
+      const input = ['First paragraph.', 'Second paragraph.', 'Third paragraph.']
+      const expected = 'First paragraph.\n\nSecond paragraph.\n\nThird paragraph.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('filters out empty strings from arrays', () => {
+      const input = ['First.', '', 'Second.', null, 'Third.']
+      const expected = 'First.\n\nSecond.\n\nThird.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('handles nested entries objects with names', () => {
+      const input = {
+        type: 'entries',
+        name: 'Special Ability',
+        entries: ['This is a description.', 'It has multiple parts.'],
+      }
+      const expected = '**Special Ability**\n\nThis is a description.\n\nIt has multiple parts.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('handles nested entries without names', () => {
+      const input = {
+        type: 'entries',
+        entries: ['Line 1', 'Line 2'],
+      }
+      const expected = 'Line 1\n\nLine 2'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('processes list objects correctly', () => {
+      const input = {
+        type: 'list',
+        items: ['First item', 'Second item', 'Third item'],
+      }
+      const expected = '- First item\n- Second item\n- Third item'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('handles complex nested structures', () => {
+      const input = [
+        'Main description with {@spell mage armor}.',
+        {
+          type: 'entries',
+          name: 'At Higher Levels',
+          entries: ['When you cast using a {@dice 1d6} slot.'],
+        },
+      ]
+      const expected =
+        'Main description with *mage armor*.\n\n**At Higher Levels**\n\nWhen you cast using a 1d6 slot.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('handles table objects (simplified)', () => {
+      const input = {
+        type: 'table',
+        caption: 'Damage by Level',
+      }
+      const expected = '**Table: Damage by Level**'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('strips unrecognized tags as fallback', () => {
+      const input = 'This has {@unknownTag some content} in it.'
+      const expected = 'This has some content in it.'
+      expect(sanitizeText(input)).toBe(expected)
+    })
+
+    it('handles deeply nested arrays and objects', () => {
+      const input = [
+        'Outer text',
+        {
+          type: 'entries',
+          name: 'Section',
+          entries: [
+            'Inner text with {@spell shield}',
+            {
+              type: 'list',
+              items: ['Bullet {@damage 1d4}', 'Another bullet'],
+            },
+          ],
+        },
+      ]
+      const result = sanitizeText(input)
+      expect(result).toContain('Outer text')
+      expect(result).toContain('**Section**')
+      expect(result).toContain('Inner text with *shield*')
+      expect(result).toContain('- Bullet 1d4')
+      expect(result).toContain('- Another bullet')
+    })
+  })
+})

--- a/test/rulesStore.test.ts
+++ b/test/rulesStore.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useRulesStore } from '../src/stores/rulesStore'
+
+describe('rulesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('initializes with default rules from rules.js', () => {
+    const store = useRulesStore()
+
+    expect(store.abilities).toBeDefined()
+    expect(store.abilities.str).toBe('Strength')
+    expect(store.skills).toBeDefined()
+    expect(store.classes).toBeDefined()
+    expect(store.species).toBeDefined()
+    expect(store.backgrounds).toBeDefined()
+    expect(store.spells).toEqual([])
+    expect(store.feats).toEqual([])
+  })
+
+  it('exposes getters for rules data', () => {
+    const store = useRulesStore()
+
+    expect(store.allClasses).toBeDefined()
+    expect(store.allSpecies).toBeDefined()
+    expect(store.allBackgrounds).toBeDefined()
+    expect(store.allSpells).toEqual([])
+    expect(store.allFeats).toEqual([])
+  })
+
+  describe('importData', () => {
+    it('imports spells array correctly', () => {
+      const store = useRulesStore()
+      const testSpells = [
+        { name: 'Fireball', level: 3, desc: 'A burst of flame' },
+        { name: 'Magic Missile', level: 1, desc: 'Magical darts' },
+      ]
+
+      store.importData('spells', testSpells)
+
+      expect(store.spells).toHaveLength(2)
+      expect(store.spells[0]).toEqual(testSpells[0])
+      expect(store.spells[1]).toEqual(testSpells[1])
+    })
+
+    it('imports feats array correctly', () => {
+      const store = useRulesStore()
+      const testFeats = [
+        { name: 'Alert', desc: 'Always on the lookout' },
+        { name: 'Lucky', desc: 'Fortune favors you' },
+      ]
+
+      store.importData('feats', testFeats)
+
+      expect(store.feats).toHaveLength(2)
+      expect(store.feats[0]).toEqual(testFeats[0])
+    })
+
+    it('replaces existing data when importing', () => {
+      const store = useRulesStore()
+      const firstBatch = [{ name: 'Spell1', level: 1 }]
+      const secondBatch = [
+        { name: 'Spell2', level: 2 },
+        { name: 'Spell3', level: 3 },
+      ]
+
+      store.importData('spells', firstBatch)
+      expect(store.spells).toHaveLength(1)
+
+      store.importData('spells', secondBatch)
+      expect(store.spells).toHaveLength(2)
+      expect(store.spells[0]).toEqual(secondBatch[0])
+    })
+
+    it('converts array to object for classes/species/backgrounds', () => {
+      const store = useRulesStore()
+      const testClasses = [
+        { name: 'Wizard', hitDie: 'd6' },
+        { name: 'Fighter', hitDie: 'd10' },
+      ]
+
+      store.importData('classes', testClasses)
+
+      expect(typeof store.classes).toBe('object')
+      expect((store.classes as any).Wizard).toBeDefined()
+      expect((store.classes as any).Wizard.hitDie).toBe('d6')
+      expect((store.classes as any).Fighter).toBeDefined()
+    })
+
+    it('warns and ignores invalid categories', () => {
+      const store = useRulesStore()
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      store.importData('invalidCategory', [{ foo: 'bar' }])
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid category'),
+        expect.any(Array),
+      )
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('resetCategory', () => {
+    it('resets spells to empty array', () => {
+      const store = useRulesStore()
+      store.importData('spells', [{ name: 'Fireball' }])
+      expect(store.spells).toHaveLength(1)
+
+      store.resetCategory('spells')
+      expect(store.spells).toEqual([])
+    })
+
+    it('resets classes to original rules.js data', () => {
+      const store = useRulesStore()
+      const originalClasses = { ...store.classes }
+
+      store.importData('classes', [{ name: 'CustomClass' }])
+      expect((store.classes as any).CustomClass).toBeDefined()
+
+      store.resetCategory('classes')
+      expect(store.classes).toEqual(originalClasses)
+      expect((store.classes as any).CustomClass).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Implements foundational infrastructure for 5e.tools data import pipeline.

Closes #20
Closes #21

## Summary

This PR adds the two foundational pieces needed for the 5e.tools import system:
1. **rulesStore** - A Pinia store that wraps rules.js and allows dynamic data injection
2. **fiveToolsAdapter** - Utilities to convert 5e.tools JSON format to clean Markdown

## Changes

### rulesStore (Issue #20)
- Created `src/stores/rulesStore.ts` as a Pinia store
- Initializes from existing `rules.js` for backward compatibility
- Exposes `importData(category, dataArray)` to replace data at runtime
- Exposes `resetCategory(category)` to restore defaults
- Supports: spells, feats, classes, species, backgrounds
- Converts array imports to keyed objects where appropriate

### fiveToolsAdapter (Issue #21)
- Created `src/utils/fiveToolsAdapter.ts` with `sanitizeText()` function
- Recursively processes 5e.tools entries arrays
- Converts inline tags to Markdown:
  - `{@spell Fireball}` → `*Fireball*`
  - `{@damage 2d6}` → `2d6`
  - `{@dc 15}` → `DC 15`
  - `{@hit +5}` → `+5`
  - `{@creature Goblin}` → `**Goblin**`
  - And many more (ability, skill, condition, item, atk types)
- Handles nested structures (entries, lists, tables)

## Testing
- Added 31 new tests (49 total now passing)
- Full coverage of both modules
- Type-check passes
- No regressions

## Next Steps
These are the foundation for:
- #23 - Spells import adapter
- #24 - Feats import adapter  
- #22 - Import UI

Part of Epic: #10
